### PR TITLE
tests: arch: Update rest of arch tests to leverage new ZTEST API.

### DIFF
--- a/tests/arch/arm64/arm64_gicv3_its/src/main.c
+++ b/tests/arch/arm64/arm64_gicv3_its/src/main.c
@@ -34,7 +34,7 @@ static void lpi_irq_handle(const void *parameter)
 
 unsigned int vectors[ITS_TEST_NUM_DEVS][ITS_TEST_NUM_ITES];
 
-static void test_gicv3_its_alloc(void)
+ZTEST(its_func, test_gicv3_its_alloc)
 {
 	int devn, event_id;
 	const struct device *dev = DEVICE_DT_INST_GET(0);
@@ -57,7 +57,7 @@ static void test_gicv3_its_alloc(void)
 	}
 }
 
-static void test_gicv3_its_connect(void)
+ZTEST(its_func, test_gicv3_its_connect)
 {
 	int devn, event_id;
 	const struct device *dev = DEVICE_DT_INST_GET(0);
@@ -78,7 +78,7 @@ static void test_gicv3_its_connect(void)
 	}
 }
 
-static void test_gicv3_its_irq_simple(void)
+ZTEST(its_func, test_gicv3_its_irq_simple)
 {
 	const struct device *dev = DEVICE_DT_INST_GET(0);
 	unsigned int irqn = vectors[0][0];
@@ -101,7 +101,7 @@ static void test_gicv3_its_irq_simple(void)
 			irqn, device_id, event_id);
 }
 
-static void test_gicv3_its_irq_disable(void)
+ZTEST(its_func, test_gicv3_its_irq_disable)
 {
 	const struct device *dev = DEVICE_DT_INST_GET(0);
 	unsigned int irqn = vectors[0][0];
@@ -140,7 +140,7 @@ static void test_gicv3_its_irq_disable(void)
 			irqn, device_id, event_id);
 }
 
-static void test_gicv3_its_irq(void)
+ZTEST(its_func, test_gicv3_its_irq)
 {
 	int devn, event_id;
 	const struct device *dev = DEVICE_DT_INST_GET(0);
@@ -172,13 +172,4 @@ static void test_gicv3_its_irq(void)
 	}
 }
 
-void test_main(void)
-{
-	ztest_test_suite(its_func,
-			 ztest_unit_test(test_gicv3_its_alloc),
-			 ztest_unit_test(test_gicv3_its_connect),
-			 ztest_unit_test(test_gicv3_its_irq_simple),
-			 ztest_unit_test(test_gicv3_its_irq_disable),
-			 ztest_unit_test(test_gicv3_its_irq));
-	ztest_run_test_suite(its_func);
-}
+ZTEST_SUITE(its_func, NULL, NULL, NULL, NULL, NULL);

--- a/tests/arch/x86/cpu_scrubs_regs/src/main.c
+++ b/tests/arch/x86/cpu_scrubs_regs/src/main.c
@@ -69,7 +69,7 @@ static inline void z_vrfy_test_cpu_write_reg(void)
  *
  * @ingroup kernel_memprotect_tests
  */
-void test_syscall_cpu_scrubs_regs(void)
+ZTEST_USER(test_x86_cpu_scrubs_regs, test_syscall_cpu_scrubs_regs)
 {
 #if CONFIG_X86
 #ifndef CONFIG_X86_64
@@ -125,9 +125,4 @@ void test_syscall_cpu_scrubs_regs(void)
 #endif
 }
 
-void test_main(void)
-{
-	ztest_test_suite(test_x86_cpu_scrubs_regs,
-		ztest_user_unit_test(test_syscall_cpu_scrubs_regs));
-	ztest_run_test_suite(test_x86_cpu_scrubs_regs);
-}
+ZTEST_SUITE(test_x86_cpu_scrubs_regs, NULL, NULL, NULL, NULL, NULL);

--- a/tests/arch/x86/nmi/src/main.c
+++ b/tests/arch/x86/nmi/src/main.c
@@ -53,7 +53,7 @@ bool z_x86_do_kernel_nmi(const z_arch_esf_t *esf)
 	return true;
 }
 
-void test_nmi_handler(void)
+ZTEST(nmi, test_nmi_handler)
 {
 	TC_PRINT("Testing to see interrupt handler executes properly\n");
 
@@ -66,8 +66,4 @@ void test_nmi_handler(void)
 		      int_handler_executed);
 }
 
-void test_main(void)
-{
-	ztest_test_suite(nmi, ztest_unit_test(test_nmi_handler));
-	ztest_run_test_suite(nmi);
-}
+ZTEST_SUITE(nmi, NULL, NULL, NULL, NULL, NULL);

--- a/tests/arch/x86/pagetables/src/main.c
+++ b/tests/arch/x86/pagetables/src/main.c
@@ -74,7 +74,7 @@ static pentry_t get_entry(pentry_t *flags, void *addr)
  *
  * @ingroup kernel_memprotect_tests
  */
-void test_ram_perms(void)
+ZTEST(x86_pagetables, test_ram_perms)
 {
 	uint8_t *pos;
 
@@ -200,7 +200,7 @@ void test_ram_perms(void)
  *
  * @ingroup kernel_memprotect_tests
  */
-void test_null_map(void)
+ZTEST(x86_pagetables, test_null_map)
 {
 	int level;
 	pentry_t entry;
@@ -233,7 +233,7 @@ void z_vrfy_dump_my_ptables(void)
  *
  * @ingroup kernel_memprotect_tests
  */
-void test_dump_ptables(void)
+ZTEST_USER(x86_pagetables, test_dump_ptables)
 {
 #if CONFIG_SRAM_SIZE > (32 << 10)
 	/*
@@ -246,13 +246,4 @@ void test_dump_ptables(void)
 #endif
 }
 
-void test_main(void)
-{
-	ztest_test_suite(x86_pagetables,
-			 ztest_unit_test(test_ram_perms),
-			 ztest_unit_test(test_null_map),
-			 ztest_unit_test(test_dump_ptables),
-			 ztest_user_unit_test(test_dump_ptables)
-			 );
-	ztest_run_test_suite(x86_pagetables);
-}
+ZTEST_SUITE(x86_pagetables, NULL, NULL, NULL, NULL, NULL);

--- a/tests/arch/x86/static_idt/src/main.c
+++ b/tests/arch/x86/static_idt/src/main.c
@@ -109,7 +109,7 @@ extern void *_EXCEPTION_STUB_NAME(exc_divide_error_handler, IV_DIVIDE_ERROR);
  * and exception stubs are installed at the correct place.
  *
  */
-void test_idt_stub(void)
+ZTEST(static_idt, test_idt_stub)
 {
 	struct segment_descriptor *p_idt_entry;
 	uint32_t offset;
@@ -156,7 +156,7 @@ void idt_spur_task(void *arg1, void *arg2, void *arg3)
  * and spurious interrupt using various method, the registered handler
  * should get called
  */
-void test_static_idt(void)
+ZTEST(static_idt, test_static_idt)
 {
 	volatile int error;     /* used to create a divide by zero error */
 
@@ -200,11 +200,4 @@ void test_static_idt(void)
 			  "Spurious handler did not execute as expected");
 }
 
-void test_main(void)
-{
-	ztest_test_suite(static_idt,
-			 ztest_unit_test(test_idt_stub),
-			 ztest_unit_test(test_static_idt)
-			 );
-	ztest_run_test_suite(static_idt);
-}
+ZTEST_SUITE(static_idt, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
The following were not updated due to their non-use of old ztest:

1. `tests/arch/xtensa_asm2/src`
2. `tests/arch/x86/info/src`
3. `tests/arch/arm64/arm64_psci/src`
4. `tests/arch/arm/arm_no_multithreading/src`

These are also tracked in our spreadsheet.