### PR TITLE
tests: benchmarks: Update ztest API for benchmarks

### DIFF
--- a/tests/benchmarks/cmsis_dsp/basicmath/src/f32.c
+++ b/tests/benchmarks/cmsis_dsp/basicmath/src/f32.c
@@ -147,7 +147,7 @@ static const uint32_t input2[256] = {
 	0xbf6a57bf, 0xbe9b9d13, 0x3ddf83ce, 0xbec67d55
 	};
 
-void test_benchmark_vec_add_f32(void)
+ZTEST(basicmath_f32_benchmark, test_benchmark_vec_add_f32)
 {
 	uint32_t irq_key, timestamp, timespan;
 	float32_t *output;
@@ -174,7 +174,7 @@ void test_benchmark_vec_add_f32(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_sub_f32(void)
+ZTEST(basicmath_f32_benchmark, test_benchmark_vec_sub_f32)
 {
 	uint32_t irq_key, timestamp, timespan;
 	float32_t *output;
@@ -201,7 +201,7 @@ void test_benchmark_vec_sub_f32(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_mult_f32(void)
+ZTEST(basicmath_f32_benchmark, test_benchmark_vec_mult_f32)
 {
 	uint32_t irq_key, timestamp, timespan;
 	float32_t *output;
@@ -228,7 +228,7 @@ void test_benchmark_vec_mult_f32(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_abs_f32(void)
+ZTEST(basicmath_f32_benchmark, test_benchmark_vec_abs_f32)
 {
 	uint32_t irq_key, timestamp, timespan;
 	float32_t *output;
@@ -253,7 +253,7 @@ void test_benchmark_vec_abs_f32(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_negate_f32(void)
+ZTEST(basicmath_f32_benchmark, test_benchmark_vec_negate_f32)
 {
 	uint32_t irq_key, timestamp, timespan;
 	float32_t *output;
@@ -278,7 +278,7 @@ void test_benchmark_vec_negate_f32(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_offset_f32(void)
+ZTEST(basicmath_f32_benchmark, test_benchmark_vec_offset_f32)
 {
 	uint32_t irq_key, timestamp, timespan;
 	float32_t *output;
@@ -303,7 +303,7 @@ void test_benchmark_vec_offset_f32(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_scale_f32(void)
+ZTEST(basicmath_f32_benchmark, test_benchmark_vec_scale_f32)
 {
 	uint32_t irq_key, timestamp, timespan;
 	float32_t *output;
@@ -328,7 +328,7 @@ void test_benchmark_vec_scale_f32(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_dot_prod_f32(void)
+ZTEST(basicmath_f32_benchmark, test_benchmark_vec_dot_prod_f32)
 {
 	uint32_t irq_key, timestamp, timespan;
 	float32_t output;
@@ -348,12 +348,4 @@ void test_benchmark_vec_dot_prod_f32(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-ztest_register_test_suite(basicmath_f32_benchmark, NULL,
-			  ztest_unit_test(test_benchmark_vec_add_f32),
-			  ztest_unit_test(test_benchmark_vec_sub_f32),
-			  ztest_unit_test(test_benchmark_vec_mult_f32),
-			  ztest_unit_test(test_benchmark_vec_abs_f32),
-			  ztest_unit_test(test_benchmark_vec_negate_f32),
-			  ztest_unit_test(test_benchmark_vec_offset_f32),
-			  ztest_unit_test(test_benchmark_vec_scale_f32),
-			  ztest_unit_test(test_benchmark_vec_dot_prod_f32));
+ZTEST_SUITE(basicmath_f32_benchmark, NULL, NULL, NULL, NULL, NULL);

--- a/tests/benchmarks/cmsis_dsp/basicmath/src/q15.c
+++ b/tests/benchmarks/cmsis_dsp/basicmath/src/q15.c
@@ -83,7 +83,7 @@ static const q15_t input2[256] = {
 	0xEA8B, 0x0959, 0x2D02, 0xD265, 0x3343, 0x0521, 0x4A77, 0xE225
 	};
 
-void test_benchmark_vec_add_q15(void)
+ZTEST(basicmath_q15_benchmark, test_benchmark_vec_add_q15)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q15_t *output;
@@ -108,7 +108,7 @@ void test_benchmark_vec_add_q15(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_sub_q15(void)
+ZTEST(basicmath_q15_benchmark, test_benchmark_vec_sub_q15)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q15_t *output;
@@ -133,7 +133,7 @@ void test_benchmark_vec_sub_q15(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_mult_q15(void)
+ZTEST(basicmath_q15_benchmark, test_benchmark_vec_mult_q15)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q15_t *output;
@@ -158,7 +158,7 @@ void test_benchmark_vec_mult_q15(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_abs_q15(void)
+ZTEST(basicmath_q15_benchmark, test_benchmark_vec_abs_q15)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q15_t *output;
@@ -183,7 +183,7 @@ void test_benchmark_vec_abs_q15(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_negate_q15(void)
+ZTEST(basicmath_q15_benchmark, test_benchmark_vec_negate_q15)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q15_t *output;
@@ -208,7 +208,7 @@ void test_benchmark_vec_negate_q15(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_offset_q15(void)
+ZTEST(basicmath_q15_benchmark, test_benchmark_vec_offset_q15)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q15_t *output;
@@ -233,7 +233,7 @@ void test_benchmark_vec_offset_q15(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_scale_q15(void)
+ZTEST(basicmath_q15_benchmark, test_benchmark_vec_scale_q15)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q15_t *output;
@@ -258,7 +258,7 @@ void test_benchmark_vec_scale_q15(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_dot_prod_q15(void)
+ZTEST(basicmath_q15_benchmark, test_benchmark_vec_dot_prod_q15)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q63_t output;
@@ -276,12 +276,4 @@ void test_benchmark_vec_dot_prod_q15(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-ztest_register_test_suite(basicmath_q15_benchmark, NULL,
-			  ztest_unit_test(test_benchmark_vec_add_q15),
-			  ztest_unit_test(test_benchmark_vec_sub_q15),
-			  ztest_unit_test(test_benchmark_vec_mult_q15),
-			  ztest_unit_test(test_benchmark_vec_abs_q15),
-			  ztest_unit_test(test_benchmark_vec_negate_q15),
-			  ztest_unit_test(test_benchmark_vec_offset_q15),
-			  ztest_unit_test(test_benchmark_vec_scale_q15),
-			  ztest_unit_test(test_benchmark_vec_dot_prod_q15));
+ZTEST_SUITE(basicmath_q15_benchmark, NULL, NULL, NULL, NULL, NULL);

--- a/tests/benchmarks/cmsis_dsp/basicmath/src/q31.c
+++ b/tests/benchmarks/cmsis_dsp/basicmath/src/q31.c
@@ -172,7 +172,7 @@ void test_benchmark_vec_add_q31(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_sub_q31(void)
+ZTEST(basicmath_q31_benchmark, test_benchmark_vec_sub_q31)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q31_t *output;
@@ -197,7 +197,7 @@ void test_benchmark_vec_sub_q31(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_mult_q31(void)
+ZTEST(basicmath_q31_benchmark, test_benchmark_vec_mult_q31)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q31_t *output;
@@ -222,7 +222,7 @@ void test_benchmark_vec_mult_q31(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_abs_q31(void)
+ZTEST(basicmath_q31_benchmark, test_benchmark_vec_abs_q31)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q31_t *output;
@@ -247,7 +247,7 @@ void test_benchmark_vec_abs_q31(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_negate_q31(void)
+ZTEST(basicmath_q31_benchmark, test_benchmark_vec_negate_q31)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q31_t *output;
@@ -272,7 +272,7 @@ void test_benchmark_vec_negate_q31(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_offset_q31(void)
+ZTEST(basicmath_q31_benchmark, test_benchmark_vec_offset_q31)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q31_t *output;
@@ -297,7 +297,7 @@ void test_benchmark_vec_offset_q31(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_scale_q31(void)
+ZTEST(basicmath_q31_benchmark, test_benchmark_vec_scale_q31)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q31_t *output;
@@ -322,7 +322,7 @@ void test_benchmark_vec_scale_q31(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_dot_prod_q31(void)
+ZTEST(basicmath_q31_benchmark, test_benchmark_vec_dot_prod_q31)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q63_t output;
@@ -340,12 +340,4 @@ void test_benchmark_vec_dot_prod_q31(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-ztest_register_test_suite(basicmath_q31_benchmark, NULL,
-			  ztest_unit_test(test_benchmark_vec_add_q31),
-			  ztest_unit_test(test_benchmark_vec_sub_q31),
-			  ztest_unit_test(test_benchmark_vec_mult_q31),
-			  ztest_unit_test(test_benchmark_vec_abs_q31),
-			  ztest_unit_test(test_benchmark_vec_negate_q31),
-			  ztest_unit_test(test_benchmark_vec_offset_q31),
-			  ztest_unit_test(test_benchmark_vec_scale_q31),
-			  ztest_unit_test(test_benchmark_vec_dot_prod_q31));
+ZTEST_SUITE(basicmath_q31_benchmark, NULL, NULL, NULL, NULL, NULL);

--- a/tests/benchmarks/cmsis_dsp/basicmath/src/q7.c
+++ b/tests/benchmarks/cmsis_dsp/basicmath/src/q7.c
@@ -83,7 +83,7 @@ static const q7_t input2[PATTERN_LENGTH] = {
 	0xF7, 0xDB, 0xD0, 0x03, 0x4F, 0xE7, 0x0D, 0x1A
 	};
 
-void test_benchmark_vec_add_q7(void)
+ZTEST(basicmath_q7_benchmark, test_benchmark_vec_add_q7)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q7_t *output;
@@ -108,7 +108,7 @@ void test_benchmark_vec_add_q7(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_sub_q7(void)
+ZTEST(basicmath_q7_benchmark, test_benchmark_vec_sub_q7)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q7_t *output;
@@ -132,8 +132,7 @@ void test_benchmark_vec_sub_q7(void)
 	/* Print result */
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
-
-void test_benchmark_vec_mult_q7(void)
+ZTEST(basicmath_q7_benchmark, test_benchmark_vec_mult_q7)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q7_t *output;
@@ -158,7 +157,7 @@ void test_benchmark_vec_mult_q7(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_abs_q7(void)
+ZTEST(basicmath_q7_benchmark, test_benchmark_vec_abs_q7)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q7_t *output;
@@ -183,7 +182,7 @@ void test_benchmark_vec_abs_q7(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_negate_q7(void)
+ZTEST(basicmath_q7_benchmark, test_benchmark_vec_negate_q7)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q7_t *output;
@@ -208,7 +207,7 @@ void test_benchmark_vec_negate_q7(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_offset_q7(void)
+ZTEST(basicmath_q7_benchmark, test_benchmark_vec_offset_q7)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q7_t *output;
@@ -233,7 +232,7 @@ void test_benchmark_vec_offset_q7(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_scale_q7(void)
+ZTEST(basicmath_q7_benchmark, test_benchmark_vec_scale_q7)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q7_t *output;
@@ -258,7 +257,7 @@ void test_benchmark_vec_scale_q7(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-void test_benchmark_vec_dot_prod_q7(void)
+ZTEST(basicmath_q7_benchmark, test_benchmark_vec_dot_prod_q7)
 {
 	uint32_t irq_key, timestamp, timespan;
 	q31_t output;
@@ -276,12 +275,4 @@ void test_benchmark_vec_dot_prod_q7(void)
 	TC_PRINT(BENCHMARK_TYPE " = %u\n", timespan);
 }
 
-ztest_register_test_suite(basicmath_q7_benchmark, NULL,
-			  ztest_unit_test(test_benchmark_vec_add_q7),
-			  ztest_unit_test(test_benchmark_vec_sub_q7),
-			  ztest_unit_test(test_benchmark_vec_mult_q7),
-			  ztest_unit_test(test_benchmark_vec_abs_q7),
-			  ztest_unit_test(test_benchmark_vec_negate_q7),
-			  ztest_unit_test(test_benchmark_vec_offset_q7),
-			  ztest_unit_test(test_benchmark_vec_scale_q7),
-			  ztest_unit_test(test_benchmark_vec_dot_prod_q7));
+ZTEST_SUITE(basicmath_q7_benchmark, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Many tests here did not use the old ztest API. Please see sheet.

Keeping this as a single PR to stay organized.